### PR TITLE
chore(go): use go 1.17

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## To be Released
 
+* chore(go): use go 1.17
 * Bump go.etcd.io/etcd/client/v3 from 3.5.0 to 3.5.4
 * Bump github.com/stretchr/testify from 1.7.0 to 1.7.1
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/Scalingo/go-etcd-lock/v5
 
-go 1.14
+go 1.17
 
 require (
 	github.com/golang/mock v1.6.0


### PR DESCRIPTION
The fix for CVE-2022-29526 is only available in Go 1.17 and 1.18.