### PR TITLE
feat(lock): add read-to-write lock upgrade functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,62 @@ if err != nil {
 defer writeLock.Release()
 ```
 
-If you acquire a read lock and later decide the resource must be changed, you can upgrade that read lock to a write lock with `(*lock.EtcdRWLock).Upgrade()` or `WaitUpgrade()`. The upgrade releases the read lock before taking the write lock, so you must re-read or re-validate the protected resource once the write lock has been granted.
+## Read to Write Upgrade
+
+If you acquire a read lock and later decide the resource must be changed, you can upgrade that read lock to a write lock with `(*lock.EtcdRWLock).Upgrade()` or `WaitUpgrade()`.
+
+The upgrade is not atomic:
+- writer intent is published first, so later readers stop entering
+- the read lock is released
+- the code then acquires the write lock
+
+Because of that gap, you must re-read or re-validate the protected resource once the write lock has been granted, before applying any mutation such as repairing network state, updating configuration, or creating/deleting a dependent resource.
+
+```mermaid
+sequenceDiagram
+    participant C as Caller
+    participant R as RW read lock
+    participant E as etcd queue
+    participant W as Other readers/writers
+
+    C->>R: AcquireRead()
+    R->>E: register reader entry
+    C->>C: inspect resource state
+
+    alt resource must be updated
+        C->>R: WaitUpgrade()
+        R->>E: publish writer intent
+        R->>E: remove reader entry
+        Note over W,E: New readers stop entering
+        W-->>E: existing readers/writers drain
+        R->>E: acquire legacy write lock
+        E-->>C: write lock granted
+        C->>C: re-read / re-validate resource
+        C->>C: apply mutation
+    end
+```
+
+```go
+readLock, err := locker.AcquireRead("/network", 60)
+if err != nil {
+	panic(err)
+}
+
+rwReadLock, ok := readLock.(*lock.EtcdRWLock)
+if !ok {
+	panic("unexpected lock type")
+}
+
+// Read and validate the resource first.
+// If it needs to be updated, upgrade to a write lock.
+writeLock, err := rwReadLock.WaitUpgrade()
+if err != nil {
+	panic(err)
+}
+defer writeLock.Release()
+
+// Re-read or re-validate here before applying the update.
+```
 
 ## Testing
 

--- a/README.md
+++ b/README.md
@@ -83,6 +83,8 @@ if err != nil {
 defer writeLock.Release()
 ```
 
+If you acquire a read lock and later decide the resource must be changed, you can upgrade that read lock to a write lock with `(*lock.EtcdRWLock).Upgrade()` or `WaitUpgrade()`. The upgrade releases the read lock before taking the write lock, so you must re-read or re-validate the protected resource once the write lock has been granted.
+
 ## Testing
 
 You need a etcd instance running on `localhost:2379`, then:

--- a/lock/rwlock.go
+++ b/lock/rwlock.go
@@ -37,6 +37,15 @@ type RWLocker interface {
 
 type EtcdRWLocker struct {
 	writer *EtcdLocker
+	// clientMu protects temporary client swapping used by upgrade tests.
+	clientMu sync.RWMutex
+	client   *etcdv3.Client
+	// tryLockTimeout is the timeout duration for one attempt to create the lock.
+	tryLockTimeout time.Duration
+	// maxTryLockTimeout is the maximal time the wait variants can block.
+	maxTryLockTimeout time.Duration
+	// cooldownTryLockDuration is the pause between retries while waiting.
+	cooldownTryLockDuration time.Duration
 }
 
 type EtcdRWLock struct {
@@ -211,11 +220,22 @@ func (locker *EtcdRWLocker) acquireRead(ctx context.Context, key string, ttl int
 	}
 }
 
+func (locker *EtcdRWLocker) writeLocker() *EtcdLocker {
+	// RW writes intentionally reuse the legacy writer path so old and new writers
+	// keep the same writer-vs-writer ordering during rollout.
+	return &EtcdLocker{
+		client:                  locker.etcdClient(),
+		tryLockTimeout:          locker.tryLockTimeout,
+		maxTryLockTimeout:       locker.maxTryLockTimeout,
+		cooldownTryLockDuration: locker.cooldownTryLockDuration,
+	}
+}
+
 func (locker *EtcdRWLocker) createReaderKey(ctx context.Context, lockKey string, leaseID etcdv3.LeaseID) (int64, error) {
 	ctx, cancel := context.WithTimeout(ctx, locker.writer.tryLockTimeout)
 	defer cancel()
 
-	resp, err := locker.writer.client.Txn(ctx).
+	resp, err := locker.writer.etcdClient().client.Txn(ctx).
 		If(etcdv3.Compare(etcdv3.CreateRevision(lockKey), "=", 0)).
 		Then(etcdv3.OpPut(lockKey, "", etcdv3.WithLease(leaseID))).
 		Commit()
@@ -262,7 +282,7 @@ func (locker *EtcdRWLocker) writerState(ctx context.Context, resourceKey string,
 	defer cancel()
 
 	queueOpts := append([]etcdv3.OpOption{etcdv3.WithPrefix()}, opts...)
-	resp, err := locker.writer.client.Get(
+	resp, err := locker.writer.etcdClient().Get(
 		ctx,
 		rwQueuePrefix(resourceKey),
 		queueOpts...,
@@ -271,7 +291,7 @@ func (locker *EtcdRWLocker) writerState(ctx context.Context, resourceKey string,
 		return nil, nil, errors.Wrap(ctx, err, "list queued writers")
 	}
 	intentOpts := append([]etcdv3.OpOption{etcdv3.WithPrefix(), etcdv3.WithLimit(1)}, opts...)
-	intentResp, err := locker.writer.client.Get(
+	intentResp, err := locker.writer.etcdClient().Get(
 		ctx,
 		rwWriterIntentsPrefix(resourceKey),
 		intentOpts...,
@@ -385,4 +405,18 @@ func rwMetadataResourcePrefix(resourceKey string, kind string) string {
 	// in a single opaque path segment, so prefix scans stay scoped to one lock.
 	// Example: "/etcd-lock/my-lock" becomes one "<encoded-resource>" segment.
 	return fmt.Sprintf("%s/%s/%s/", rwMetadataPrefix, kind, base64.RawURLEncoding.EncodeToString([]byte(resourceKey)))
+}
+
+func (locker *EtcdRWLocker) etcdClient() *etcdv3.Client {
+	locker.clientMu.RLock()
+	defer locker.clientMu.RUnlock()
+
+	return locker.client
+}
+
+func (locker *EtcdRWLocker) setEtcdClient(client *etcdv3.Client) {
+	locker.clientMu.Lock()
+	defer locker.clientMu.Unlock()
+
+	locker.client = client
 }

--- a/lock/rwlock.go
+++ b/lock/rwlock.go
@@ -42,10 +42,21 @@ type EtcdRWLocker struct {
 type EtcdRWLock struct {
 	*sync.Mutex
 
-	client   *etcdv3.Client
-	session  *concurrency.Session
-	lockKey  string
+	client *etcdv3.Client
+	// locker carries the RW timing configuration used for upgrade attempts.
+	locker *EtcdRWLocker
+	// resourceKey is the shared etcd lock namespace for this protected resource.
+	resourceKey string
+	// lockKey is the current reader entry stored in etcd for this lock instance.
+	lockKey string
+	// ttl is reused if the read lock is upgraded into a write lock.
+	ttl int
+	// session owns the current etcd lease backing the reader entry.
+	session *concurrency.Session
+	// released avoids duplicate cleanup from explicit release and TTL expiry.
 	released bool
+	// upgrading suppresses normal release while the read lock is being converted.
+	upgrading bool
 }
 
 func NewEtcdRWLocker(client *etcdv3.Client, opts ...EtcdLockerOpt) RWLocker {
@@ -148,10 +159,13 @@ func (locker *EtcdRWLocker) acquireRead(ctx context.Context, key string, ttl int
 		}
 
 		lock := &EtcdRWLock{
-			Mutex:   &sync.Mutex{},
-			client:  locker.writer.client,
-			session: session,
-			lockKey: rwReaderKey(resourceKey, session.Lease()),
+			Mutex:       &sync.Mutex{},
+			client:      locker.writer.client,
+			locker:      locker,
+			resourceKey: resourceKey,
+			ttl:         ttl,
+			session:     session,
+			lockKey:     rwReaderKey(resourceKey, session.Lease()),
 		}
 		myRev, err := locker.createReaderKey(ctx, lock.lockKey, session.Lease())
 		if err != nil {
@@ -293,6 +307,9 @@ func (l *EtcdRWLock) Release() error {
 	defer l.Unlock()
 
 	if l.released {
+		return nil
+	}
+	if l.upgrading {
 		return nil
 	}
 

--- a/lock/rwlock.go
+++ b/lock/rwlock.go
@@ -57,6 +57,8 @@ type EtcdRWLock struct {
 	released bool
 	// upgrading suppresses normal release while the read lock is being converted.
 	upgrading bool
+	// releaseRequested records a release that arrived while upgrade was in flight.
+	releaseRequested bool
 }
 
 func NewEtcdRWLocker(client *etcdv3.Client, opts ...EtcdLockerOpt) RWLocker {
@@ -310,6 +312,7 @@ func (l *EtcdRWLock) Release() error {
 		return nil
 	}
 	if l.upgrading {
+		l.releaseRequested = true
 		return nil
 	}
 

--- a/lock/rwlock.go
+++ b/lock/rwlock.go
@@ -82,7 +82,11 @@ func NewEtcdRWLocker(client *etcdv3.Client, opts ...EtcdLockerOpt) RWLocker {
 	}
 
 	return &EtcdRWLocker{
-		writer: writer,
+		writer:                  writer,
+		client:                  client,
+		tryLockTimeout:          writer.tryLockTimeout,
+		maxTryLockTimeout:       writer.maxTryLockTimeout,
+		cooldownTryLockDuration: writer.cooldownTryLockDuration,
 	}
 }
 
@@ -235,7 +239,7 @@ func (locker *EtcdRWLocker) createReaderKey(ctx context.Context, lockKey string,
 	ctx, cancel := context.WithTimeout(ctx, locker.writer.tryLockTimeout)
 	defer cancel()
 
-	resp, err := locker.writer.etcdClient().client.Txn(ctx).
+	resp, err := locker.etcdClient().Txn(ctx).
 		If(etcdv3.Compare(etcdv3.CreateRevision(lockKey), "=", 0)).
 		Then(etcdv3.OpPut(lockKey, "", etcdv3.WithLease(leaseID))).
 		Commit()
@@ -282,7 +286,7 @@ func (locker *EtcdRWLocker) writerState(ctx context.Context, resourceKey string,
 	defer cancel()
 
 	queueOpts := append([]etcdv3.OpOption{etcdv3.WithPrefix()}, opts...)
-	resp, err := locker.writer.etcdClient().Get(
+	resp, err := locker.etcdClient().Get(
 		ctx,
 		rwQueuePrefix(resourceKey),
 		queueOpts...,
@@ -291,7 +295,7 @@ func (locker *EtcdRWLocker) writerState(ctx context.Context, resourceKey string,
 		return nil, nil, errors.Wrap(ctx, err, "list queued writers")
 	}
 	intentOpts := append([]etcdv3.OpOption{etcdv3.WithPrefix(), etcdv3.WithLimit(1)}, opts...)
-	intentResp, err := locker.writer.etcdClient().Get(
+	intentResp, err := locker.etcdClient().Get(
 		ctx,
 		rwWriterIntentsPrefix(resourceKey),
 		intentOpts...,

--- a/lock/rwlock_test.go
+++ b/lock/rwlock_test.go
@@ -659,6 +659,36 @@ func waitUntilLegacyWriterQueued(t *testing.T, key string) {
 	t.Fatalf("legacy writer was never observed in queue for key %q", key)
 }
 
+func waitUntilWriterIntentExists(t *testing.T, key string) {
+	t.Helper()
+
+	resourceKey := addPrefix(key)
+	intentPrefix := rwWriterIntentsPrefix(resourceKey)
+	cli := client()
+	defer cli.Close()
+
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		resp, err := cli.Get(t.Context(), intentPrefix, etcdv3.WithPrefix(), etcdv3.WithLimit(1))
+		require.NoError(t, err)
+		if len(resp.Kvs) > 0 {
+			return
+		}
+
+		time.Sleep(20 * time.Millisecond)
+	}
+
+	t.Fatalf("writer intent was never observed for key %q", key)
+}
+
+func mustRWReadLock(t *testing.T, lock Lock) *EtcdRWLock {
+	t.Helper()
+
+	rwLock, ok := lock.(*EtcdRWLock)
+	require.True(t, ok)
+	return rwLock
+}
+
 func assertAlreadyLocked(t *testing.T, err error) {
 	t.Helper()
 

--- a/lock/rwlock_upgrade.go
+++ b/lock/rwlock_upgrade.go
@@ -29,6 +29,8 @@ func (l *EtcdRWLock) upgrade(wait bool) (Lock, error) {
 		return nil, errgo.New("nil lock")
 	}
 
+	// Upgrade is deliberately non-atomic: we first mark the intent to write,
+	// then release the read entry, then compete for the legacy write lock.
 	l.Lock()
 	if l.released {
 		l.Unlock()
@@ -55,7 +57,10 @@ func (l *EtcdRWLock) upgrade(wait bool) (Lock, error) {
 
 	writeLocker := locker.writeLocker()
 	intentKey := rwWriterIntentKey(resourceKey, writeSession.Lease())
-	if err := writeLocker.createWriterIntent(intentKey, writeSession.Lease()); err != nil {
+	// Publishing writer intent before dropping the read lock prevents later
+	// readers from slipping in during the upgrade window.
+	err = writeLocker.createWriterIntent(intentKey, writeSession.Lease())
+	if err != nil {
 		l.finishUpgrade()
 		closeErr := closeRWSession(writeSession)
 		return nil, noteAcquireFailure(err, closeErr, "fail to upgrade read lock")
@@ -109,6 +114,9 @@ func (locker *EtcdRWLocker) acquireWriteWithSession(resourceKey string, session 
 	timeout := time.NewTimer(locker.maxTryLockTimeout)
 	defer timeout.Stop()
 
+	// Upgrade reuses the same retry model as the normal write path:
+	// per-attempt tryLockTimeout, cooldown between retries, and a global
+	// maxTryLockTimeout for the whole wait.
 	tryLockErr := error(nil)
 	writeLocker := locker.writeLocker()
 	for {

--- a/lock/rwlock_upgrade.go
+++ b/lock/rwlock_upgrade.go
@@ -1,0 +1,158 @@
+package lock
+
+import (
+	"context"
+	"sync"
+	"time"
+
+	"go.etcd.io/etcd/client/v3/concurrency"
+	"gopkg.in/errgo.v1"
+)
+
+// Upgrade tries to turn a read lock into a write lock without waiting.
+// The read lock is released during the upgrade attempt, so callers must
+// re-check the protected resource once the write lock is acquired.
+func (l *EtcdRWLock) Upgrade() (Lock, error) {
+	return l.upgrade(false)
+}
+
+// WaitUpgrade tries to turn a read lock into a write lock, waiting up to the
+// configured max timeout for competing readers or writers to drain.
+// The read lock is released during the upgrade attempt, so callers must
+// re-check the protected resource once the write lock is acquired.
+func (l *EtcdRWLock) WaitUpgrade() (Lock, error) {
+	return l.upgrade(true)
+}
+
+func (l *EtcdRWLock) upgrade(wait bool) (Lock, error) {
+	if l == nil {
+		return nil, errgo.New("nil lock")
+	}
+
+	l.Lock()
+	if l.released {
+		l.Unlock()
+		return nil, errgo.New("lock already released")
+	}
+	if l.upgrading {
+		l.Unlock()
+		return nil, errgo.New("lock upgrade already in progress")
+	}
+	l.upgrading = true
+	locker := l.locker
+	resourceKey := l.resourceKey
+	ttl := l.ttl
+	readKey := l.lockKey
+	readSession := l.session
+	client := l.client
+	l.Unlock()
+
+	writeSession, err := concurrency.NewSession(client, concurrency.WithTTL(ttl))
+	if err != nil {
+		l.finishUpgrade()
+		return nil, err
+	}
+
+	writeLocker := locker.writeLocker()
+	intentKey := rwWriterIntentKey(resourceKey, writeSession.Lease())
+	if err := writeLocker.createWriterIntent(intentKey, writeSession.Lease()); err != nil {
+		l.finishUpgrade()
+		closeErr := closeRWSession(writeSession)
+		return nil, noteAcquireFailure(err, closeErr, "fail to upgrade read lock")
+	}
+
+	releaseErr := l.releaseForUpgrade(readKey, readSession)
+	if releaseErr != nil {
+		l.finishUpgrade()
+		closeErr := closeRWSession(writeSession)
+		return nil, noteAcquireFailure(releaseErr, closeErr, "fail to upgrade read lock")
+	}
+
+	writeLock, err := locker.acquireWriteWithSession(resourceKey, writeSession, ttl, wait, true)
+	if err != nil {
+		return nil, errgo.Notef(err, "fail to upgrade read lock")
+	}
+
+	return writeLock, nil
+}
+
+func (l *EtcdRWLock) releaseForUpgrade(readKey string, session *concurrency.Session) error {
+	l.Lock()
+	defer l.Unlock()
+
+	_, err := l.client.Delete(context.Background(), readKey)
+	closeErr := closeRWSession(session)
+	if err != nil {
+		return err
+	}
+	if closeErr != nil {
+		return closeErr
+	}
+
+	l.released = true
+	l.upgrading = false
+	l.lockKey = ""
+	l.session = nil
+
+	return nil
+}
+
+func (l *EtcdRWLock) finishUpgrade() {
+	l.Lock()
+	defer l.Unlock()
+
+	l.upgrading = false
+}
+
+func (locker *EtcdRWLocker) acquireWriteWithSession(resourceKey string, session *concurrency.Session, ttl int, wait bool, intentCreated bool) (Lock, error) {
+	mutex := concurrency.NewMutex(session, resourceKey)
+	timeout := time.NewTimer(locker.maxTryLockTimeout)
+	defer timeout.Stop()
+
+	tryLockErr := error(nil)
+	writeLocker := locker.writeLocker()
+	for {
+		select {
+		case <-timeout.C:
+			closeErr := closeRWSession(session)
+			if tryLockErr == context.DeadlineExceeded {
+				return nil, &ErrAlreadyLocked{}
+			}
+			return nil, noteAcquireFailure(errgo.Notef(tryLockErr, "fail to acquire lock"), closeErr, "fail to acquire write lock")
+		default:
+		}
+
+		if !intentCreated {
+			tryLockErr = writeLocker.createWriterIntent(rwWriterIntentKey(resourceKey, session.Lease()), session.Lease())
+			if tryLockErr == nil {
+				intentCreated = true
+			} else {
+				time.Sleep(locker.cooldownTryLockDuration)
+				continue
+			}
+		}
+
+		tryLockErr = writeLocker.tryLock(mutex)
+		shouldWait := wait && tryLockErr == context.DeadlineExceeded
+		shouldRetry := shouldWait || (tryLockErr != nil && tryLockErr != context.DeadlineExceeded)
+		if shouldRetry {
+			time.Sleep(locker.cooldownTryLockDuration)
+			continue
+		}
+		if tryLockErr == context.DeadlineExceeded {
+			closeErr := closeRWSession(session)
+			if closeErr != nil {
+				return nil, noteAcquireFailure(&ErrAlreadyLocked{}, closeErr, "fail to acquire write lock")
+			}
+			return nil, &ErrAlreadyLocked{}
+		}
+		break
+	}
+
+	lock := &EtcdLock{mutex: mutex, Mutex: &sync.Mutex{}, session: session}
+	time.AfterFunc(time.Duration(ttl)*time.Second, func() {
+		_ = lock.Release()
+	})
+
+	return lock, nil
+}

--- a/lock/rwlock_upgrade.go
+++ b/lock/rwlock_upgrade.go
@@ -5,9 +5,11 @@ import (
 	"sync"
 	"time"
 
+	"go.etcd.io/etcd/api/v3/v3rpc/rpctypes"
 	etcdv3 "go.etcd.io/etcd/client/v3"
 	"go.etcd.io/etcd/client/v3/concurrency"
-	"gopkg.in/errgo.v1"
+
+	"github.com/Scalingo/go-utils/errors/v3"
 )
 
 // Upgrade tries to turn a read lock into a write lock without waiting.
@@ -26,8 +28,10 @@ func (l *EtcdRWLock) WaitUpgrade() (Lock, error) {
 }
 
 func (l *EtcdRWLock) upgrade(wait bool) (Lock, error) {
+	ctx := context.Background()
+
 	if l == nil {
-		return nil, errgo.New("nil lock")
+		return nil, errors.New(ctx, "nil lock")
 	}
 	deadline := time.Now().Add(l.locker.maxTryLockTimeout)
 
@@ -36,11 +40,11 @@ func (l *EtcdRWLock) upgrade(wait bool) (Lock, error) {
 	l.Lock()
 	if l.released {
 		l.Unlock()
-		return nil, errgo.New("lock already released")
+		return nil, errors.New(ctx, "lock already released")
 	}
 	if l.upgrading {
 		l.Unlock()
-		return nil, errgo.New("lock upgrade already in progress")
+		return nil, errors.New(ctx, "lock upgrade already in progress")
 	}
 	l.upgrading = true
 	locker := l.locker
@@ -58,7 +62,7 @@ func (l *EtcdRWLock) upgrade(wait bool) (Lock, error) {
 	}
 	defer func() {
 		if writeSession != nil {
-			_ = closeRWSession(writeSession)
+			_ = closeRWSessionWithCtx(ctx, writeSession)
 		}
 	}()
 
@@ -71,24 +75,30 @@ func (l *EtcdRWLock) upgrade(wait bool) (Lock, error) {
 		if err == errUpgradeReleased {
 			return nil, l.abortUpgrade(readKey, readSession, writeSession)
 		}
-		closeErr := closeRWSession(writeSession)
-		return nil, noteAcquireFailure(err, closeErr, "fail to upgrade read lock")
+		closeErr := closeRWSessionWithCtx(ctx, writeSession)
+		if closeErr != nil {
+			return nil, errors.Wrapf(ctx, err, "upgrade read lock (cleanup: %v)", closeErr)
+		}
+		return nil, errors.Wrap(ctx, err, "upgrade read lock")
 	}
 
 	if l.isReleaseRequested() {
 		return nil, l.abortUpgrade(readKey, readSession, writeSession)
 	}
 
-	releaseErr := l.releaseForUpgrade(readKey, readSession)
+	releaseErr := l.releaseForUpgrade(ctx, readKey, readSession)
 	if releaseErr != nil {
 		l.finishUpgrade()
-		closeErr := closeRWSession(writeSession)
-		return nil, noteAcquireFailure(releaseErr, closeErr, "fail to upgrade read lock")
+		closeErr := closeRWSessionWithCtx(ctx, writeSession)
+		if closeErr != nil {
+			return nil, errors.Wrapf(ctx, releaseErr, "upgrade read lock (cleanup: %v)", closeErr)
+		}
+		return nil, errors.Wrap(ctx, releaseErr, "upgrade read lock")
 	}
 
-	writeLock, err := locker.acquireWriteWithSession(resourceKey, writeSession, ttl, wait, true, deadline, nil)
+	writeLock, err := locker.acquireWriteWithSession(ctx, resourceKey, writeSession, ttl, wait, true, deadline, nil)
 	if err != nil {
-		return nil, errgo.Notef(err, "fail to upgrade read lock")
+		return nil, errors.Wrap(ctx, err, "upgrade read lock")
 	}
 	// Ownership of the session moves to the returned write lock.
 	writeSession = nil
@@ -96,12 +106,12 @@ func (l *EtcdRWLock) upgrade(wait bool) (Lock, error) {
 	return writeLock, nil
 }
 
-func (l *EtcdRWLock) releaseForUpgrade(readKey string, session *concurrency.Session) error {
+func (l *EtcdRWLock) releaseForUpgrade(ctx context.Context, readKey string, session *concurrency.Session) error {
 	l.Lock()
 	defer l.Unlock()
 
-	_, err := l.client.Delete(context.Background(), readKey)
-	closeErr := closeRWSession(session)
+	_, err := l.client.Delete(ctx, readKey)
+	closeErr := closeRWSessionWithCtx(ctx, session)
 	if err != nil {
 		return err
 	}
@@ -125,28 +135,36 @@ func (l *EtcdRWLock) finishUpgrade() {
 	l.releaseRequested = false
 }
 
-func (locker *EtcdRWLocker) acquireWriteWithSession(resourceKey string, session *concurrency.Session, ttl int, wait bool, intentCreated bool, deadline time.Time, abortRequested func() bool) (Lock, error) {
+func (locker *EtcdRWLocker) acquireWriteWithSession(ctx context.Context, resourceKey string, session *concurrency.Session, ttl int, wait bool, intentCreated bool, deadline time.Time, abortRequested func() bool) (Lock, error) {
 	// Upgrade reuses the same retry model as the normal write path:
 	// per-attempt tryLockTimeout, cooldown between retries, and a global
 	// maxTryLockTimeout for the whole wait.
 	mutex := concurrency.NewMutex(session, resourceKey)
 	tryLockErr := error(nil)
 	writeLocker := locker.writeLocker()
+	intentKey := rwWriterIntentKey(resourceKey, session.Lease())
 	for {
 		if abortRequested != nil && abortRequested() {
-			closeErr := closeRWSession(session)
-			return nil, noteAcquireFailure(errUpgradeReleased, closeErr, "upgrade cancelled by release")
+			closeErr := closeRWSessionWithCtx(ctx, session)
+			if closeErr != nil {
+				return nil, errors.Wrapf(ctx, errUpgradeReleased, "upgrade cancelled by release (cleanup: %v)", closeErr)
+			}
+			return nil, errors.Wrap(ctx, errUpgradeReleased, "upgrade cancelled by release")
 		}
 		if time.Now().After(deadline) {
-			closeErr := closeRWSession(session)
+			closeErr := closeRWSessionWithCtx(ctx, session)
 			if tryLockErr == context.DeadlineExceeded {
 				return nil, &ErrAlreadyLocked{}
 			}
-			return nil, noteAcquireFailure(errgo.Notef(tryLockErr, "fail to acquire lock"), closeErr, "fail to acquire write lock")
+			acquireErr := errors.Wrap(ctx, tryLockErr, "acquire lock")
+			if closeErr != nil {
+				return nil, errors.Wrapf(ctx, acquireErr, "acquire write lock (cleanup: %v)", closeErr)
+			}
+			return nil, errors.Wrap(ctx, acquireErr, "acquire write lock")
 		}
 
 		if !intentCreated {
-			tryLockErr = writeLocker.createWriterIntent(rwWriterIntentKey(resourceKey, session.Lease()), session.Lease())
+			tryLockErr = writeLocker.createWriterIntent(ctx, intentKey, session.Lease())
 			if tryLockErr == nil {
 				intentCreated = true
 			} else {
@@ -155,7 +173,7 @@ func (locker *EtcdRWLocker) acquireWriteWithSession(resourceKey string, session 
 			}
 		}
 
-		tryLockErr = writeLocker.tryLock(mutex)
+		tryLockErr = writeLocker.tryLock(ctx, mutex)
 		shouldWait := wait && tryLockErr == context.DeadlineExceeded
 		shouldRetry := shouldWait || (tryLockErr != nil && tryLockErr != context.DeadlineExceeded)
 		if shouldRetry {
@@ -163,24 +181,45 @@ func (locker *EtcdRWLocker) acquireWriteWithSession(resourceKey string, session 
 			continue
 		}
 		if tryLockErr == context.DeadlineExceeded {
-			closeErr := closeRWSession(session)
+			closeErr := closeRWSessionWithCtx(ctx, session)
 			if closeErr != nil {
-				return nil, noteAcquireFailure(&ErrAlreadyLocked{}, closeErr, "fail to acquire write lock")
+				return nil, errors.Wrapf(ctx, &ErrAlreadyLocked{}, "acquire write lock (cleanup: %v)", closeErr)
 			}
 			return nil, &ErrAlreadyLocked{}
 		}
 		break
 	}
 
-	lock := &EtcdLock{mutex: mutex, Mutex: &sync.Mutex{}, session: session}
-	time.AfterFunc(time.Duration(ttl)*time.Second, func() {
-		_ = lock.Release()
-	})
+	lock := &EtcdLock{
+		Mutex:   &sync.Mutex{},
+		client:  writeLocker.client,
+		mutex:   mutex,
+		session: session,
+	}
+	if intentCreated {
+		lock.intentKey = intentKey
+	}
+	err := writeLocker.waitForReaders(ctx, resourceKey, wait, deadline)
+	if err != nil {
+		releaseErr := releaseLockWithCtx(ctx, lock)
+		var alreadyLocked *ErrAlreadyLocked
+		if errors.As(err, &alreadyLocked) {
+			if releaseErr != nil {
+				return nil, errors.Wrapf(ctx, &ErrAlreadyLocked{}, "acquire write lock (cleanup: %v)", releaseErr)
+			}
+			return nil, errors.Wrap(ctx, err, "acquire write lock")
+		}
+		if releaseErr != nil {
+			return nil, errors.Wrapf(ctx, err, "acquire write lock (cleanup: %v)", releaseErr)
+		}
+		return nil, errors.Wrap(ctx, err, "acquire write lock")
+	}
+	scheduleRelease(lock, ttl)
 
 	return lock, nil
 }
 
-var errUpgradeReleased = errgo.New("lock released during upgrade")
+var errUpgradeReleased = errors.New(context.Background(), "lock released during upgrade")
 
 func (locker *EtcdRWLocker) createWriterIntentWithRetry(intentKey string, leaseID etcdv3.LeaseID, deadline time.Time, wait bool, abortRequested func() bool) error {
 	lastErr := error(nil)
@@ -195,7 +234,7 @@ func (locker *EtcdRWLocker) createWriterIntentWithRetry(intentKey string, leaseI
 			return lastErr
 		}
 
-		lastErr = locker.writeLocker().createWriterIntent(intentKey, leaseID)
+		lastErr = locker.writeLocker().createWriterIntent(context.Background(), intentKey, leaseID)
 		if lastErr == nil {
 			return nil
 		}
@@ -214,6 +253,8 @@ func (l *EtcdRWLock) isReleaseRequested() bool {
 }
 
 func (l *EtcdRWLock) abortUpgrade(readKey string, readSession *concurrency.Session, writeSession *concurrency.Session) error {
+	ctx := context.Background()
+
 	l.Lock()
 	l.released = true
 	l.upgrading = false
@@ -222,18 +263,40 @@ func (l *EtcdRWLock) abortUpgrade(readKey string, readSession *concurrency.Sessi
 	l.session = nil
 	l.Unlock()
 
-	_, err := l.client.Delete(context.Background(), readKey)
-	readCloseErr := closeRWSession(readSession)
-	writeCloseErr := closeRWSession(writeSession)
+	_, err := l.client.Delete(ctx, readKey)
+	readCloseErr := closeRWSessionWithCtx(ctx, readSession)
+	writeCloseErr := closeRWSessionWithCtx(ctx, writeSession)
 	cleanupErr := firstNonNil(readCloseErr, writeCloseErr)
 	if err != nil {
-		return noteAcquireFailure(errUpgradeReleased, err, "upgrade cancelled by release")
+		return errors.Wrap(ctx, errUpgradeReleased, err.Error())
 	}
 	if cleanupErr != nil {
-		return noteAcquireFailure(errUpgradeReleased, cleanupErr, "upgrade cancelled by release")
+		return errors.Wrapf(ctx, errUpgradeReleased, "upgrade cancelled by release (cleanup: %v)", cleanupErr)
 	}
 
 	return errUpgradeReleased
+}
+
+func closeRWSessionWithCtx(ctx context.Context, session *concurrency.Session) error {
+	if session == nil {
+		return nil
+	}
+
+	err := session.Close()
+	if err == nil || err == rpctypes.ErrLeaseNotFound {
+		return nil
+	}
+
+	return errors.Wrap(ctx, err, "close rw lock session")
+}
+
+func releaseLockWithCtx(ctx context.Context, lock Lock) error {
+	err := lock.Release()
+	if err == nil {
+		return nil
+	}
+
+	return errors.Wrap(ctx, err, "release lock")
 }
 
 func firstNonNil(errs ...error) error {

--- a/lock/rwlock_upgrade.go
+++ b/lock/rwlock_upgrade.go
@@ -5,6 +5,7 @@ import (
 	"sync"
 	"time"
 
+	etcdv3 "go.etcd.io/etcd/client/v3"
 	"go.etcd.io/etcd/client/v3/concurrency"
 	"gopkg.in/errgo.v1"
 )
@@ -28,6 +29,7 @@ func (l *EtcdRWLock) upgrade(wait bool) (Lock, error) {
 	if l == nil {
 		return nil, errgo.New("nil lock")
 	}
+	deadline := time.Now().Add(l.locker.maxTryLockTimeout)
 
 	// Upgrade is deliberately non-atomic: we first mark the intent to write,
 	// then release the read entry, then compete for the legacy write lock.
@@ -54,16 +56,27 @@ func (l *EtcdRWLock) upgrade(wait bool) (Lock, error) {
 		l.finishUpgrade()
 		return nil, err
 	}
+	defer func() {
+		if writeSession != nil {
+			_ = closeRWSession(writeSession)
+		}
+	}()
 
-	writeLocker := locker.writeLocker()
 	intentKey := rwWriterIntentKey(resourceKey, writeSession.Lease())
 	// Publishing writer intent before dropping the read lock prevents later
 	// readers from slipping in during the upgrade window.
-	err = writeLocker.createWriterIntent(intentKey, writeSession.Lease())
+	err = locker.createWriterIntentWithRetry(intentKey, writeSession.Lease(), deadline, wait, l.isReleaseRequested)
 	if err != nil {
 		l.finishUpgrade()
+		if err == errUpgradeReleased {
+			return nil, l.abortUpgrade(readKey, readSession, writeSession)
+		}
 		closeErr := closeRWSession(writeSession)
 		return nil, noteAcquireFailure(err, closeErr, "fail to upgrade read lock")
+	}
+
+	if l.isReleaseRequested() {
+		return nil, l.abortUpgrade(readKey, readSession, writeSession)
 	}
 
 	releaseErr := l.releaseForUpgrade(readKey, readSession)
@@ -73,10 +86,12 @@ func (l *EtcdRWLock) upgrade(wait bool) (Lock, error) {
 		return nil, noteAcquireFailure(releaseErr, closeErr, "fail to upgrade read lock")
 	}
 
-	writeLock, err := locker.acquireWriteWithSession(resourceKey, writeSession, ttl, wait, true)
+	writeLock, err := locker.acquireWriteWithSession(resourceKey, writeSession, ttl, wait, true, deadline, nil)
 	if err != nil {
 		return nil, errgo.Notef(err, "fail to upgrade read lock")
 	}
+	// Ownership of the session moves to the returned write lock.
+	writeSession = nil
 
 	return writeLock, nil
 }
@@ -107,27 +122,27 @@ func (l *EtcdRWLock) finishUpgrade() {
 	defer l.Unlock()
 
 	l.upgrading = false
+	l.releaseRequested = false
 }
 
-func (locker *EtcdRWLocker) acquireWriteWithSession(resourceKey string, session *concurrency.Session, ttl int, wait bool, intentCreated bool) (Lock, error) {
-	mutex := concurrency.NewMutex(session, resourceKey)
-	timeout := time.NewTimer(locker.maxTryLockTimeout)
-	defer timeout.Stop()
-
+func (locker *EtcdRWLocker) acquireWriteWithSession(resourceKey string, session *concurrency.Session, ttl int, wait bool, intentCreated bool, deadline time.Time, abortRequested func() bool) (Lock, error) {
 	// Upgrade reuses the same retry model as the normal write path:
 	// per-attempt tryLockTimeout, cooldown between retries, and a global
 	// maxTryLockTimeout for the whole wait.
+	mutex := concurrency.NewMutex(session, resourceKey)
 	tryLockErr := error(nil)
 	writeLocker := locker.writeLocker()
 	for {
-		select {
-		case <-timeout.C:
+		if abortRequested != nil && abortRequested() {
+			closeErr := closeRWSession(session)
+			return nil, noteAcquireFailure(errUpgradeReleased, closeErr, "upgrade cancelled by release")
+		}
+		if time.Now().After(deadline) {
 			closeErr := closeRWSession(session)
 			if tryLockErr == context.DeadlineExceeded {
 				return nil, &ErrAlreadyLocked{}
 			}
 			return nil, noteAcquireFailure(errgo.Notef(tryLockErr, "fail to acquire lock"), closeErr, "fail to acquire write lock")
-		default:
 		}
 
 		if !intentCreated {
@@ -163,4 +178,69 @@ func (locker *EtcdRWLocker) acquireWriteWithSession(resourceKey string, session 
 	})
 
 	return lock, nil
+}
+
+var errUpgradeReleased = errgo.New("lock released during upgrade")
+
+func (locker *EtcdRWLocker) createWriterIntentWithRetry(intentKey string, leaseID etcdv3.LeaseID, deadline time.Time, wait bool, abortRequested func() bool) error {
+	lastErr := error(nil)
+	for {
+		if abortRequested != nil && abortRequested() {
+			return errUpgradeReleased
+		}
+		if time.Now().After(deadline) {
+			if lastErr == nil {
+				return context.DeadlineExceeded
+			}
+			return lastErr
+		}
+
+		lastErr = locker.writeLocker().createWriterIntent(intentKey, leaseID)
+		if lastErr == nil {
+			return nil
+		}
+		if !wait {
+			return lastErr
+		}
+		time.Sleep(locker.cooldownTryLockDuration)
+	}
+}
+
+func (l *EtcdRWLock) isReleaseRequested() bool {
+	l.Lock()
+	defer l.Unlock()
+
+	return l.releaseRequested
+}
+
+func (l *EtcdRWLock) abortUpgrade(readKey string, readSession *concurrency.Session, writeSession *concurrency.Session) error {
+	l.Lock()
+	l.released = true
+	l.upgrading = false
+	l.releaseRequested = false
+	l.lockKey = ""
+	l.session = nil
+	l.Unlock()
+
+	_, err := l.client.Delete(context.Background(), readKey)
+	readCloseErr := closeRWSession(readSession)
+	writeCloseErr := closeRWSession(writeSession)
+	cleanupErr := firstNonNil(readCloseErr, writeCloseErr)
+	if err != nil {
+		return noteAcquireFailure(errUpgradeReleased, err, "upgrade cancelled by release")
+	}
+	if cleanupErr != nil {
+		return noteAcquireFailure(errUpgradeReleased, cleanupErr, "upgrade cancelled by release")
+	}
+
+	return errUpgradeReleased
+}
+
+func firstNonNil(errs ...error) error {
+	for _, err := range errs {
+		if err != nil {
+			return err
+		}
+	}
+	return nil
 }

--- a/lock/rwlock_upgrade_test.go
+++ b/lock/rwlock_upgrade_test.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/require"
+	etcdv3 "go.etcd.io/etcd/client/v3"
 )
 
 func TestRWLockUpgrade(t *testing.T) {
@@ -84,4 +85,120 @@ func TestRWLockUpgrade(t *testing.T) {
 		require.NotNil(t, nextReadLock)
 		require.NoError(t, nextReadLock.Release())
 	})
+
+	t.Run("wait upgrade retries writer intent publication", func(t *testing.T) {
+		locker := mustRWLocker(t, testRWLocker(
+			WithTryLockTimeout(100*time.Millisecond),
+			WithCooldownTryLockDuration(50*time.Millisecond),
+			WithMaxTryLockTimeout(2*time.Second),
+		))
+		liveClient := locker.client
+		readLock, err := locker.AcquireRead("/rw-upgrade-intent-retry", 3)
+		require.NoError(t, err)
+		rwReadLock := mustRWReadLock(t, readLock)
+
+		brokenClient := newBrokenEtcdClient(t)
+		locker.client = brokenClient
+		t.Cleanup(func() {
+			locker.client = liveClient
+			require.NoError(t, brokenClient.Close())
+		})
+
+		writeErr := make(chan error, 1)
+		writeReady := make(chan Lock, 1)
+		t1 := time.Now()
+		go func() {
+			lock, err := rwReadLock.WaitUpgrade()
+			writeErr <- err
+			writeReady <- lock
+		}()
+
+		waitUntilUpgradeInProgress(t, rwReadLock)
+		time.Sleep(200 * time.Millisecond)
+		locker.client = liveClient
+
+		require.NoError(t, <-writeErr)
+		writeLock := <-writeReady
+		require.NotNil(t, writeLock)
+		duration := time.Since(t1)
+		require.GreaterOrEqual(t, duration, 200*time.Millisecond)
+		require.Less(t, duration, 2*time.Second)
+		require.NoError(t, writeLock.Release())
+	})
+
+	t.Run("release during a pending upgrade cancels it and frees the read lock", func(t *testing.T) {
+		locker := mustRWLocker(t, testRWLocker(
+			WithTryLockTimeout(100*time.Millisecond),
+			WithCooldownTryLockDuration(50*time.Millisecond),
+			WithMaxTryLockTimeout(2*time.Second),
+		))
+		liveClient := locker.client
+		readLock, err := locker.AcquireRead("/rw-upgrade-release-cancels", 3)
+		require.NoError(t, err)
+		rwReadLock := mustRWReadLock(t, readLock)
+
+		brokenClient := newBrokenEtcdClient(t)
+		locker.client = brokenClient
+		t.Cleanup(func() {
+			locker.client = liveClient
+			require.NoError(t, brokenClient.Close())
+		})
+
+		writeErr := make(chan error, 1)
+		go func() {
+			_, err := rwReadLock.WaitUpgrade()
+			writeErr <- err
+		}()
+
+		waitUntilUpgradeInProgress(t, rwReadLock)
+		time.Sleep(150 * time.Millisecond)
+		require.NoError(t, readLock.Release())
+
+		err = <-writeErr
+		require.Error(t, err)
+		require.ErrorContains(t, err, "lock released during upgrade")
+
+		locker.client = liveClient
+		writeLock, err := locker.AcquireWrite("/rw-upgrade-release-cancels", 3)
+		require.NoError(t, err)
+		require.NotNil(t, writeLock)
+		require.NoError(t, writeLock.Release())
+	})
+}
+
+func mustRWLocker(t *testing.T, locker RWLocker) *EtcdRWLocker {
+	t.Helper()
+
+	rwLocker, ok := locker.(*EtcdRWLocker)
+	require.True(t, ok)
+	return rwLocker
+}
+
+func newBrokenEtcdClient(t *testing.T) *etcdv3.Client {
+	t.Helper()
+
+	client, err := etcdv3.New(etcdv3.Config{
+		Endpoints:   []string{"127.0.0.1:1"},
+		DialTimeout: 100 * time.Millisecond,
+	})
+	require.NoError(t, err)
+	return client
+}
+
+func waitUntilUpgradeInProgress(t *testing.T, lock *EtcdRWLock) {
+	t.Helper()
+
+	deadline := time.Now().Add(time.Second)
+	for time.Now().Before(deadline) {
+		lock.Lock()
+		upgrading := lock.upgrading
+		lock.Unlock()
+		if upgrading {
+			return
+		}
+
+		time.Sleep(10 * time.Millisecond)
+	}
+
+	t.Fatal("upgrade never entered progress state")
 }

--- a/lock/rwlock_upgrade_test.go
+++ b/lock/rwlock_upgrade_test.go
@@ -1,0 +1,87 @@
+package lock
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestRWLockUpgrade(t *testing.T) {
+	locker := testRWLocker()
+
+	t.Run("a read lock can be upgraded to a write lock", func(t *testing.T) {
+		readLock, err := locker.AcquireRead("/rw-upgrade", 3)
+		require.NoError(t, err)
+
+		writeLock, err := mustRWReadLock(t, readLock).Upgrade()
+		require.NoError(t, err)
+		require.NotNil(t, writeLock)
+
+		require.NoError(t, readLock.Release())
+		require.NoError(t, writeLock.Release())
+	})
+
+	t.Run("wait upgrade waits for another reader to drain", func(t *testing.T) {
+		readLock1, err := locker.AcquireRead("/rw-upgrade-wait", 3)
+		require.NoError(t, err)
+		rwReadLock1 := mustRWReadLock(t, readLock1)
+
+		readLock2, err := locker.AcquireRead("/rw-upgrade-wait", 1)
+		require.NoError(t, err)
+		require.NotNil(t, readLock2)
+
+		t1 := time.Now()
+		writeLock, err := rwReadLock1.WaitUpgrade()
+		t2 := time.Now()
+
+		require.NoError(t, err)
+		require.NotNil(t, writeLock)
+		assertWaitAround(t, t2.Sub(t1))
+		require.NoError(t, writeLock.Release())
+	})
+
+	t.Run("a pending upgrade blocks new readers", func(t *testing.T) {
+		readLock1, err := locker.AcquireRead("/rw-upgrade-blocks-readers", 3)
+		require.NoError(t, err)
+		rwReadLock1 := mustRWReadLock(t, readLock1)
+
+		readLock2, err := locker.AcquireRead("/rw-upgrade-blocks-readers", 1)
+		require.NoError(t, err)
+		require.NotNil(t, readLock2)
+
+		writeErr := make(chan error, 1)
+		writeReady := make(chan Lock, 1)
+		go func() {
+			lock, err := rwReadLock1.WaitUpgrade()
+			writeErr <- err
+			writeReady <- lock
+		}()
+
+		waitUntilWriterIntentExists(t, "/rw-upgrade-blocks-readers")
+
+		readErr := make(chan error, 1)
+		readReady := make(chan Lock, 1)
+		go func() {
+			lock, err := locker.WaitAcquireRead("/rw-upgrade-blocks-readers", 1)
+			readErr <- err
+			readReady <- lock
+		}()
+
+		require.NoError(t, <-writeErr)
+		writeLock := <-writeReady
+		require.NotNil(t, writeLock)
+
+		select {
+		case err := <-readErr:
+			t.Fatalf("reader acquired before the upgraded writer was released: %v", err)
+		default:
+		}
+
+		require.NoError(t, writeLock.Release())
+		require.NoError(t, <-readErr)
+		nextReadLock := <-readReady
+		require.NotNil(t, nextReadLock)
+		require.NoError(t, nextReadLock.Release())
+	})
+}

--- a/lock/rwlock_upgrade_test.go
+++ b/lock/rwlock_upgrade_test.go
@@ -92,15 +92,15 @@ func TestRWLockUpgrade(t *testing.T) {
 			WithCooldownTryLockDuration(50*time.Millisecond),
 			WithMaxTryLockTimeout(2*time.Second),
 		))
-		liveClient := locker.client
+		liveClient := locker.etcdClient()
 		readLock, err := locker.AcquireRead("/rw-upgrade-intent-retry", 3)
 		require.NoError(t, err)
 		rwReadLock := mustRWReadLock(t, readLock)
 
 		brokenClient := newBrokenEtcdClient(t)
-		locker.client = brokenClient
+		locker.setEtcdClient(brokenClient)
 		t.Cleanup(func() {
-			locker.client = liveClient
+			locker.setEtcdClient(liveClient)
 			require.NoError(t, brokenClient.Close())
 		})
 
@@ -115,7 +115,7 @@ func TestRWLockUpgrade(t *testing.T) {
 
 		waitUntilUpgradeInProgress(t, rwReadLock)
 		time.Sleep(200 * time.Millisecond)
-		locker.client = liveClient
+		locker.setEtcdClient(liveClient)
 
 		require.NoError(t, <-writeErr)
 		writeLock := <-writeReady
@@ -132,15 +132,15 @@ func TestRWLockUpgrade(t *testing.T) {
 			WithCooldownTryLockDuration(50*time.Millisecond),
 			WithMaxTryLockTimeout(2*time.Second),
 		))
-		liveClient := locker.client
+		liveClient := locker.etcdClient()
 		readLock, err := locker.AcquireRead("/rw-upgrade-release-cancels", 3)
 		require.NoError(t, err)
 		rwReadLock := mustRWReadLock(t, readLock)
 
 		brokenClient := newBrokenEtcdClient(t)
-		locker.client = brokenClient
+		locker.setEtcdClient(brokenClient)
 		t.Cleanup(func() {
-			locker.client = liveClient
+			locker.setEtcdClient(liveClient)
 			require.NoError(t, brokenClient.Close())
 		})
 
@@ -158,7 +158,7 @@ func TestRWLockUpgrade(t *testing.T) {
 		require.Error(t, err)
 		require.ErrorContains(t, err, "lock released during upgrade")
 
-		locker.client = liveClient
+		locker.setEtcdClient(liveClient)
 		writeLock, err := locker.AcquireWrite("/rw-upgrade-release-cancels", 3)
 		require.NoError(t, err)
 		require.NotNil(t, writeLock)


### PR DESCRIPTION
## Summary

This PR builds on top of `feat/rw-locks` and adds one capability: upgrading an RW read lock into a write lock.

It does not reintroduce the RW lock feature itself. The delta here is the read-to-write upgrade flow and the tests/documentation around it.

## What this branch adds

- `(*EtcdRWLock).Upgrade()` for a non-blocking read => write upgrade attempt
- `(*EtcdRWLock).WaitUpgrade()` for a waiting read => write upgrade attempt
- upgrade-specific integration tests
- a small refactor that moves upgrade code and tests into dedicated files for readability
- README documentation for the upgrade flow

## Upgrade semantics

The upgrade path is intentionally not atomic.

Behavior:
- the read lock first publishes writer intent so new readers stop entering
- the read lock is then released
- the code attempts to acquire the write lock on the existing legacy write-lock path

That means the protected resource can change between the initial read and the moment the write lock is finally acquired. Callers therefore need to re-read or re-validate the resource after upgrade succeeds, before applying any mutation (e.g. repairing network state, updating stored configuration, or creating/deleting a dependent resource).

This tradeoff avoids deadlocking on the caller's own read lock while still preserving fairness with queued writers.

```mermaid
sequenceDiagram
    participant C as Caller
    participant R as RW read lock
    participant E as etcd queue
    participant W as Other readers/writers

    C->>R: AcquireRead()
    R->>E: register reader entry
    C->>C: inspect resource state

    alt resource must be updated
        C->>R: WaitUpgrade()
        R->>E: publish writer intent
        R->>E: remove reader entry
        Note over W,E: New readers stop entering
        W-->>E: existing readers/writers drain
        R->>E: acquire legacy write lock
        E-->>C: write lock granted
        C->>C: re-read / re-validate resource
        C->>C: apply mutation
    end
```

Timing behavior:
- `Upgrade()` follows the same single-attempt timeout behavior as a non-waiting write acquisition
- `WaitUpgrade()` follows the same retry pattern as the existing wait path, using `tryLockTimeout`, `cooldownTryLockDuration`, and `maxTryLockTimeout`
- the writer-intent publication done before the upgrade also uses the same timeout/cooldown settings

## Compatibility

This branch keeps the compatibility model introduced in `feat/rw-locks`:
- upgraded writes still acquire through the legacy write-lock mechanism
- pending upgrades publish the same writer-intent signal used to block later readers
- legacy writer behavior is unchanged

## Testing

Added real-etcd-backed coverage for:
- successful read => write upgrade
- waiting for another reader before upgrade completes
- blocking new readers while an upgrade is pending

Validated with:
```sh
GOCACHE=/tmp/go-build go test ./lock -count=1
```